### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-cache: 
-  directories: 
+cache:
+  directories:
     - $HOME/.m2
-dist: trusty
-git: 
+dist: xenial
+git:
   depth: 1
-jdk: 
-  - openjdk8
+jdk:
+  - openjdk11
 language: java

--- a/README.adoc
+++ b/README.adoc
@@ -7,6 +7,8 @@
 
 = Apartments
 
+image:https://travis-ci.com/av1m/Apartments.svg?branch=master["Build Status", link="https://travis-ci.com/av1m/Apartments"]
+
 A Java project developed by students during the link:https://github.com/oliviercailloux/java-course[Java course] taught at Université Paris-Dauphine (in link:http://www.mido.dauphine.fr/[MIDO] L3 Apprentissage).
 
 The code is hereby published under the MIT License, with their permission.


### PR DESCRIPTION
Travis causes generation errors because it is configured on the jdk8. 
In addition, Travis uses an older version of ubuntu, namely [Trusty (v.14)](http://releases.ubuntu.com/trusty/)

The purpose of this pull request is to:
* Update the connection between Travis and this repository
* Update the jdk that Travis will use to test. We will use [openjdk11](https://openjdk.java.net/projects/jdk/11/)
* Update the version of ubuntu that Travis will use. We will use [ubuntu xenial 16](http://releases.ubuntu.com/xenial/)