### PR TITLE
Update fmt-maven-plugin 🎉

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
 			<plugin>
 				<groupId>com.coveo</groupId>
 				<artifactId>fmt-maven-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.10</version>
 				<configuration>
 					<skipSortingImports>false</skipSortingImports>
 				</configuration>


### PR DESCRIPTION
The plugin [fmt-maven-plugin](https://github.com/coveooss/fmt-maven-plugin/) has finally gone to version [2.10](https://github.com/coveooss/fmt-maven-plugin/releases/tag/2.10.0), and uses version 1.8 of google-java-format.

